### PR TITLE
Adds support for the device configuration query command: GET_LIDAR_CONF

### DIFF
--- a/src/Api/Data/DataType.cs
+++ b/src/Api/Data/DataType.cs
@@ -7,6 +7,8 @@
         // GET_INFO (p. 33)
         GetInfo = 0x04,
         // GET_HEALTH (p.35)
-        GetHealth = 0x06
+        GetHealth = 0x06,
+        // GET_LIDAR_CONF (p.38)
+        LidarConfig = 0x20
     }
 }

--- a/src/Api/Data/LidarConfigType.cs
+++ b/src/Api/Data/LidarConfigType.cs
@@ -1,0 +1,17 @@
+﻿namespace RPLidar4Net.Api.Data
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <remarks>LR001_SLAMTEC_rplidar_protocol_v2.2_en / p.41</remarks>
+    public enum LidarConfigType
+        : int
+    {
+        ScanModeCount = 0x70, //Get the amount of scan modes supported by the LIDAR
+        ScanModeUsPerSample = 0x71, //Get microsecond cost per measurement sample for specific scan mode(in Q8 fixed point format)
+        ScanModeMaxDistance = 0x74, //Get max measurement distance for specific scan mode (in m, Q8 fixed point format)
+        ScanModeAnsType = 0x75, //Get the answer command type for this scan mode
+        ScaneModeTypical = 0x7C, //Get the typical scan mode id of LIDAR
+        ScanModeName = 0x7F //Get a user friendly name for the scan mode
+    }
+}

--- a/src/Api/Data/LidarConigResponse.cs
+++ b/src/Api/Data/LidarConigResponse.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace RPLidar4Net.Api.Data
+{
+    /// <summary>
+    /// Lidar Config Response
+    /// </summary>
+    public class LidarConfigDataResponse
+        : IDataResponse
+    {
+        public DataType Type { get; } = DataType.LidarConfig;
+
+        /// <summary>
+        /// The number of scan modes supported by the device
+        /// </summary>
+        public int ScanModeCount { get; set; }
+
+        /// <summary>
+        /// The id of the preferred scan mode of the device
+        /// </summary>
+        public byte TypicalScanMode { get; set; }
+     
+        /// <summary>
+        /// The user friendly name of the scan mode
+        /// </summary>
+        public byte AnswerType { get; set; }
+
+        /// <summary>
+        /// The user friendly name of the scan mode
+        /// </summary>
+        public string ScanModeName { get; set; }
+    }
+}

--- a/src/Api/Helpers/CommandHelper.cs
+++ b/src/Api/Helpers/CommandHelper.cs
@@ -1,4 +1,7 @@
 ﻿using RPLidar4Net.Api.Data;
+using System;
+using System.Collections;
+using System.Linq;
 
 namespace RPLidar4Net.Api.Helpers
 {
@@ -14,10 +17,28 @@ namespace RPLidar4Net.Api.Helpers
             return command != Command.Stop && command != Command.Reset;
         }
 
-
         public static bool GetMustSleep(Command command)
         {
             return command == Command.Reset || command == Command.Stop;
+        }
+
+        public static byte[] GetLidarConfigPayload(LidarConfigType configType, UInt16 scanMode = 0)
+        {
+            byte[] commandBytes;
+            byte[] modeBytes = new byte[0];
+            switch (configType)
+            {
+                case LidarConfigType.ScanModeCount: commandBytes = BitConverter.GetBytes((int)LidarConfigType.ScanModeCount); break;
+                case LidarConfigType.ScaneModeTypical: commandBytes = BitConverter.GetBytes((int)LidarConfigType.ScaneModeTypical); break;
+                case LidarConfigType.ScanModeName: commandBytes = BitConverter.GetBytes((int)LidarConfigType.ScanModeName); modeBytes = BitConverter.GetBytes(scanMode); break;
+                case LidarConfigType.ScanModeAnsType: commandBytes = BitConverter.GetBytes((int)LidarConfigType.ScanModeAnsType); modeBytes = BitConverter.GetBytes(scanMode); break;
+                default: commandBytes = null; break;
+            }
+
+            if (BitConverter.IsLittleEndian)
+                return commandBytes.Concat(modeBytes).ToArray();
+            else
+                return commandBytes.Reverse().Concat(modeBytes).Reverse().ToArray();
         }
     }
 }

--- a/src/Api/Helpers/DataResponseHelper.cs
+++ b/src/Api/Helpers/DataResponseHelper.cs
@@ -16,6 +16,9 @@ namespace RPLidar4Net.Api.Helpers
 
                 case DataType.GetInfo:
                     return InfoDataResponseHelper.ToInfoDataResponse(dataResponseBytes);
+
+                case DataType.LidarConfig:
+                    return LidarConfigDataResponseHelper.ToLidarConfigDataResponse(dataResponseBytes);
             }
             return null;
         }

--- a/src/Api/Helpers/LidarConfigResponseHelper.cs
+++ b/src/Api/Helpers/LidarConfigResponseHelper.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+using RPLidar4Net.Api.Data;
+
+namespace RPLidar4Net.Api.Helpers
+{
+    public class LidarConfigDataResponseHelper
+    {
+        public static LidarConfigDataResponse ToLidarConfigDataResponse(byte[] data)
+        {
+            LidarConfigDataResponse dataResponse = new LidarConfigDataResponse();
+            switch(data[0])
+            {
+                case (byte)LidarConfigType.ScanModeCount: dataResponse.ScanModeCount = BitConverter.ToUInt16(data, 4); break;
+                case (byte)LidarConfigType.ScaneModeTypical: dataResponse.TypicalScanMode = (byte)BitConverter.ToUInt16(data, 4); break;
+                case (byte)LidarConfigType.ScanModeAnsType: dataResponse.AnswerType = data[4]; break;
+                case (byte)LidarConfigType.ScanModeName: dataResponse.ScanModeName = Encoding.UTF8.GetString(data.Skip(4).Take(data.Length - 5).ToArray()); break;
+            }
+
+            return dataResponse;
+        }
+    }
+}

--- a/src/IO/RPLidarSerialDevice.cs
+++ b/src/IO/RPLidarSerialDevice.cs
@@ -21,6 +21,8 @@ namespace RPLidar4Net.IO
         /// </summary>
         private SerialPort _serialPort;
 
+        private int _readWriteTimeout;
+
         /// <summary>
         /// Connection Status
         /// </summary>
@@ -93,6 +95,7 @@ namespace RPLidar4Net.IO
             // Set the read/write timeouts
             _serialPort.ReadTimeout = timeout;
             _serialPort.WriteTimeout = timeout;
+            _readWriteTimeout = timeout;
         }
 
         /// <summary>
@@ -186,14 +189,14 @@ namespace RPLidar4Net.IO
 
         private IDataResponse ReadDataResponse(uint dataResponseLength, DataType dataType)
         {
-            byte[] dataResponseBytes = Read(dataResponseLength, 1000);
+            byte[] dataResponseBytes = Read(dataResponseLength, _readWriteTimeout);
             IDataResponse response = DataResponseHelper.ToDataResponse(dataType, dataResponseBytes);
             return response;
         }
 
         private ResponseDescriptor ReadResponseDescriptor()
         {
-            byte[] bytes = Read(Constants.ResponseDescriptorLength, 1000);
+            byte[] bytes = Read(Constants.ResponseDescriptorLength, _readWriteTimeout);
 
             string hexString = ByteHelper.ToHexString(bytes);
             Log.Information("ReadResponseDescriptor -- bytes : {@hexString}", hexString);
@@ -329,7 +332,7 @@ namespace RPLidar4Net.IO
             //Loop while we're scanning
             while (this._isScanning)
             {
-                ScanDataResponse scanDataResponse = ReadScanDataResponse(1000);
+                ScanDataResponse scanDataResponse = ReadScanDataResponse(_readWriteTimeout);
                 Point point = ScanDataResponseHelper.ToPoint(scanDataResponse);
 
                 //Check for new 360 degree scan bit

--- a/src/IO/RPLidarSerialDevice.cs
+++ b/src/IO/RPLidarSerialDevice.cs
@@ -154,15 +154,14 @@ namespace RPLidar4Net.IO
         /// Send Request to RPLidar
         /// </summary>
         /// <param name="command"></param>
-        public IDataResponse SendRequest(Command command)
+        public IDataResponse SendRequest(Command command, byte[] payload = null, bool includePayloadSize = true)
         {
             if (_isConnected)
             {
                 //Clear input buffer of any junk
                 _serialPort.DiscardInBuffer();
 
-                _serialPort.SendRequest(command);
-                //Todo: Implement Command with Payload and Checksum.
+                _serialPort.SendRequest(command, payload, includePayloadSize);
 
                 bool hasResponse = CommandHelper.GetHasResponse(command);
 
@@ -253,6 +252,38 @@ namespace RPLidar4Net.IO
         public HealthDataResponse GetHealth()
         {
             return (HealthDataResponse)this.SendRequest(Command.GetHealth);
+        }
+        /// <summary>
+        /// Get number of ScanModes via Lidar Conf
+        /// </summary>
+        public int GetScanModeCount()
+        {
+            var response = (LidarConfigDataResponse)this.SendRequest(Command.GetLidarConf, CommandHelper.GetLidarConfigPayload(LidarConfigType.ScanModeCount));
+            return response.ScanModeCount;
+        }
+        /// <summary>
+        /// Get typical ScanMode via Lidar Conf
+        /// </summary>
+        public byte GetTypicalScanMode()
+        {
+            var response = (LidarConfigDataResponse)this.SendRequest(Command.GetLidarConf, CommandHelper.GetLidarConfigPayload(LidarConfigType.ScaneModeTypical));
+            return response.TypicalScanMode;
+        }
+        /// <summary>
+        /// Get name of ScanMode via Lidar Conf
+        /// </summary>
+        public string GetScanModeName(byte scanMode)
+        {
+            var response = (LidarConfigDataResponse)this.SendRequest(Command.GetLidarConf, CommandHelper.GetLidarConfigPayload(LidarConfigType.ScanModeName, scanMode));
+            return response.ScanModeName;
+        }
+        /// <summary>
+        /// Get answer command type of ScanMode via Lidar Conf
+        /// </summary>
+        public byte GetScanModeAnswerType(byte scanMode)
+        {
+            var response = (LidarConfigDataResponse)this.SendRequest(Command.GetLidarConf, CommandHelper.GetLidarConfigPayload(LidarConfigType.ScanModeAnsType, scanMode));
+            return response.AnswerType;
         }
         /// <summary>
         /// Force Start Scanning


### PR DESCRIPTION
hey thanks for your great work on this so far.

this PR does the following 3 things:
- it adds support for the device configuration query command: GET_LIDAR_CONF
- thus needed was support for payload and checksum in the SendRequest method
- it makes sure to always use the initially set timeout

next on my list would be adding support for the ExpressScan modes.